### PR TITLE
gossip-memory: bound relays hint per public key

### DIFF
--- a/gossip/nostr-gossip-memory/src/constant.rs
+++ b/gossip/nostr-gossip-memory/src/constant.rs
@@ -8,3 +8,4 @@ use std::time::Duration;
 pub(super) const TTL_OUTDATED: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
 pub(super) const MAX_NIP17_SIZE: usize = 7;
 pub(super) const MAX_NIP65_SIZE: usize = 7;
+pub(super) const MAX_RELAYS_PER_PK: usize = 7;

--- a/gossip/nostr-gossip-memory/src/store.rs
+++ b/gossip/nostr-gossip-memory/src/store.rs
@@ -22,7 +22,7 @@ use nostr_gossip::{
 };
 use tokio::sync::RwLock;
 
-use crate::constant::{MAX_NIP17_SIZE, MAX_NIP65_SIZE, TTL_OUTDATED};
+use crate::constant::{MAX_NIP17_SIZE, MAX_NIP65_SIZE, MAX_RELAYS_PER_PK, TTL_OUTDATED};
 
 #[derive(Default)]
 struct PkRelayData {
@@ -375,13 +375,15 @@ impl NostrGossipMemory {
 
 /// Add relay per user or update the received events and bitflags.
 fn update_relay_per_user(pk_data: &mut PkData, relay_url: RelayUrl, flags: GossipFlags) {
+    let relays_len = pk_data.relays.len();
+
     match pk_data.relays.get_mut(&relay_url) {
         Some(relay_data) => {
             relay_data.bitflags.add(flags);
             relay_data.received_events = relay_data.received_events.saturating_add(1);
             relay_data.last_received_event = Some(Timestamp::now());
         }
-        None => {
+        None if relays_len <= MAX_RELAYS_PER_PK => {
             let mut relay_data = PkRelayData::default();
 
             relay_data.bitflags.add(flags);
@@ -390,6 +392,8 @@ fn update_relay_per_user(pk_data: &mut PkData, relay_url: RelayUrl, flags: Gossi
 
             pk_data.relays.insert(relay_url, relay_data);
         }
+        // ignore new relays when the maximum per-key relay limit is reached.
+        _ => {}
     }
 }
 


### PR DESCRIPTION
Related to https://github.com/nostrdevkit/nostr/issues/1433

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
Bound the relays number per public key

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/nostrdevkit/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the relevant `CHANGELOG.md` (if applicable)
- [X] I understand and can explain all code in this PR
