### PR TITLE
sdk(local_relay): reject repost of a protected event

### DIFF
--- a/nostr-sdk/CHANGELOG.md
+++ b/nostr-sdk/CHANGELOG.md
@@ -37,6 +37,7 @@
   second. The catch-all remains a finite safety fuse for malformed and non-text frames,
   while the lower operation-specific event, query, and authentication limits remain
   unchanged.
+- local_relay: Reject repost of a protected event (https://github.com/nostrdevkit/nostr/pull/1445)
 
 ## v0.45.1 - 2026/08/07
 

--- a/nostr-sdk/src/local_relay/local/inner.rs
+++ b/nostr-sdk/src/local_relay/local/inner.rs
@@ -571,6 +571,24 @@ impl InnerLocalRelay {
                     .await;
                 }
 
+                // Reject repost of a protected event
+                if matches!(event.kind, Kind::Repost | Kind::GenericRepost)
+                    && Event::from_json(&event.content).is_ok_and(|e| e.is_protected())
+                {
+                    return send_msg(
+                        ws_tx,
+                        RelayMessage::Ok {
+                            event_id: event.id,
+                            status: false,
+                            message: Cow::Owned(format!(
+                                "{}: repost of a protected event",
+                                MachineReadablePrefix::Blocked
+                            )),
+                        },
+                    )
+                    .await;
+                }
+
                 if event.kind == Kind::GiftWrap {
                     let mut pkeys = event.tags.public_keys();
                     // Ensure exactly one recipient public key: the first

--- a/nostr-sdk/src/local_relay/mod.rs
+++ b/nostr-sdk/src/local_relay/mod.rs
@@ -197,4 +197,39 @@ mod tests {
             output.failed.values().next().unwrap()
         );
     }
+
+    #[tokio::test]
+    async fn protected_repost() {
+        let relay = LocalRelay::builder()
+            .database(MemoryDatabase::unbounded())
+            .build();
+        relay.run().await.unwrap();
+
+        let keys = Keys::generate();
+        let client = Client::default();
+
+        client
+            .add_relay(relay.url().await)
+            .and_connect()
+            .await
+            .unwrap();
+
+        let event = EventBuilder::new(Kind::TextNote, "IDK")
+            .tag(Tag::protected())
+            .finalize(&keys)
+            .unwrap();
+
+        let repost = EventBuilder::new(Kind::Repost, event.as_json())
+            .tag(event.id)
+            .tag(Tag::public_key(event.pubkey))
+            .finalize(&Keys::generate())
+            .unwrap();
+
+        let output = client.send_event(&repost).await.unwrap();
+        assert!(output.success.is_empty());
+        assert_eq!(
+            "blocked: repost of a protected event",
+            output.failed.values().next().unwrap()
+        );
+    }
 }


### PR DESCRIPTION
> The `content` of a repost event is the stringified JSON of the
> reposted note. It MAY also be empty, but that is not recommended.
> Reposts of NIP-70-protected events SHOULD always have an empty
> `content`.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/nostrdevkit/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the relevant `CHANGELOG.md` (if applicable)
- [X] I understand and can explain all code in this PR
