### PR TITLE
nostr: `Into<Tag>` iterator in nip17 and nip59 extra tags

### DIFF
--- a/nostr/CHANGELOG.md
+++ b/nostr/CHANGELOG.md
@@ -35,7 +35,10 @@
 
 ### Added
 
-- impl `From<PublicKey>` for `Tag` (https://github.com/nostrdevkit/nostr/pull/1446)
+- Impl `From<PublicKey>` for `Tag` (https://github.com/nostrdevkit/nostr/pull/1446)
+- Take an `Into<Tag>` iterator instead of `Tag` iterator in
+  `GiftWrapBuilder::extra_tags`, `PrivateDirectMessageBuilder::extra_tags`
+  and `PrivateDirectMessageBuilder::rumor_extra_tags` (https://github.com/nostrdevkit/nostr/pull/1447)
 
 ## v0.45.2 - 2026/08/16
 

--- a/nostr/src/nips/nip17.rs
+++ b/nostr/src/nips/nip17.rs
@@ -114,21 +114,24 @@ impl PrivateDirectMessageBuilder {
 
     /// Extra tags to add to the **rumor** event.
     #[inline]
-    pub fn rumor_extra_tags<T>(mut self, tags: T) -> Self
+    pub fn rumor_extra_tags<I, T>(mut self, tags: I) -> Self
     where
-        T: IntoIterator<Item = Tag>,
+        I: IntoIterator<Item = T>,
+        T: Into<Tag>,
     {
-        self.rumor_extra_tags.extend(tags);
+        self.rumor_extra_tags
+            .extend(tags.into_iter().map(Into::into));
         self
     }
 
     /// Extra tags to add to the **gift wrap** event.
     #[inline]
-    pub fn extra_tags<T>(mut self, tags: T) -> Self
+    pub fn extra_tags<I, T>(mut self, tags: I) -> Self
     where
-        T: IntoIterator<Item = Tag>,
+        I: IntoIterator<Item = T>,
+        T: Into<Tag>,
     {
-        self.extra_tags.extend(tags);
+        self.extra_tags.extend(tags.into_iter().map(Into::into));
         self
     }
 

--- a/nostr/src/nips/nip59.rs
+++ b/nostr/src/nips/nip59.rs
@@ -295,11 +295,12 @@ impl GiftWrapBuilder {
 
     /// Add extra tags.
     #[inline]
-    pub fn extra_tags<T>(mut self, tags: T) -> Self
+    pub fn extra_tags<I, T>(mut self, tags: I) -> Self
     where
-        T: IntoIterator<Item = Tag>,
+        I: IntoIterator<Item = T>,
+        T: Into<Tag>,
     {
-        self.extra_tags.extend(tags);
+        self.extra_tags.extend(tags.into_iter().map(Into::into));
         self
     }
 


### PR DESCRIPTION
Take an `Into<Tag>` iterator instead of `Tag` iterator in `GiftWrapBuilder::extra_tags`, `PrivateDirectMessageBuilder::extra_tags` and `PrivateDirectMessageBuilder::rumor_extra_tags`

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/nostrdevkit/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the relevant `CHANGELOG.md` (if applicable)
- [X] I understand and can explain all code in this PR
