### PR TITLE
nostr: tolerate missing and null amounts in NIP-47 responses

### DIFF
--- a/nostr/CHANGELOG.md
+++ b/nostr/CHANGELOG.md
@@ -40,6 +40,10 @@
   `GiftWrapBuilder::extra_tags`, `PrivateDirectMessageBuilder::extra_tags`
   and `PrivateDirectMessageBuilder::rumor_extra_tags` (https://github.com/nostrdevkit/nostr/pull/1447)
 
+### Fixed
+
+- Tolerate missing and null amounts in NIP-47 responses (https://github.com/nostrdevkit/nostr/pull/1450)
+
 ## v0.45.2 - 2026/08/16
 
 ### Fixed

--- a/nostr/src/nips/nip47.rs
+++ b/nostr/src/nips/nip47.rs
@@ -942,8 +942,12 @@ pub struct LookupInvoiceResponse {
     /// Payment hash
     pub payment_hash: String,
     /// Amount in millisatoshis
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_null_as_default")]
     pub amount: u64,
     /// Fees paid in millisatoshis
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_null_as_default")]
     pub fees_paid: u64,
     /// Creation timestamp in seconds since epoch
     pub created_at: Timestamp,
@@ -1029,6 +1033,8 @@ pub struct MakeHoldInvoiceResponse {
     /// Payment hash
     pub payment_hash: String,
     /// Amount in millisatoshis
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_null_as_default")]
     pub amount: u64,
     /// Creation timestamp
     pub created_at: Timestamp,
@@ -1647,8 +1653,12 @@ pub struct PaymentNotification {
     /// Payment hash
     pub payment_hash: String,
     /// Amount in millisatoshis
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_null_as_default")]
     pub amount: u64,
     /// Fees paid in millisatoshis
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_null_as_default")]
     pub fees_paid: u64,
     /// Creation timestamp in seconds since epoch
     pub created_at: Timestamp,
@@ -1686,6 +1696,8 @@ pub struct HoldInvoiceAcceptedNotification {
     /// Payment hash
     pub payment_hash: String,
     /// Amount in millisatoshis
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_null_as_default")]
     pub amount: u64,
     /// Creation timestamp
     pub created_at: Timestamp,
@@ -1696,6 +1708,20 @@ pub struct HoldInvoiceAcceptedNotification {
     /// Optional metadata about the payment
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
+}
+
+/// Deserialize a missing or `null` value as the type's default.
+///
+/// `#[serde(default)]` alone covers only an absent key. Some wallet
+/// services send an explicit `null` for a value they have not computed yet
+/// (a fee for an unrouted payment, for example), which would otherwise be
+/// a hard parse failure.
+fn deserialize_null_as_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Default + Deserialize<'de>,
+{
+    Ok(Option::deserialize(deserializer)?.unwrap_or_default())
 }
 
 fn deserialize_empty_string_as_none<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
@@ -1717,6 +1743,27 @@ mod tests {
     use core::str::FromStr;
 
     use super::*;
+
+    /// Some wallet services omit `amount` and send `fees_paid: null` for a
+    /// payment they have not routed yet. Losing the whole response — and
+    /// with it `state`, which is what callers poll for — turns a working
+    /// wallet into one that looks unreachable.
+    #[test]
+    fn test_lookup_invoice_response_tolerates_missing_and_null_amounts() {
+        let json = r#"{
+            "type": "incoming",
+            "state": "settled",
+            "payment_hash": "0a1b2c",
+            "fees_paid": null,
+            "created_at": 1755000000
+        }"#;
+
+        let res: LookupInvoiceResponse = serde_json::from_str(json).unwrap();
+
+        assert_eq!(res.state, Some(TransactionState::Settled));
+        assert_eq!(res.amount, 0);
+        assert_eq!(res.fees_paid, 0);
+    }
 
     const NOTIFICATION_JSON: &str = r#"{
         "notification_type": "payment_received",


### PR DESCRIPTION
Fixes #1449.

`LookupInvoiceResponse` declares `amount` and `fees_paid` as required with no serde
default, so a response that omits `amount` or sends `fees_paid: null` fails to
deserialize and the whole object is lost — including `state`, which is what callers
poll a payment for. Alby does both while a payment is in flight, so `nwc`'s
`lookup_invoice` returns `Err` and a perfectly healthy wallet looks like one that
answers nothing. It breaks hold-invoice flows in particular, where polling
`lookup_invoice` until settlement is the only way to observe the invoice resolving.

Same class of problem as the empty-string handling already present on the optional
string fields of these structs; the numeric fields never got equivalent treatment.

## What changed

A `deserialize_null_as_default` helper, alongside the existing
`deserialize_empty_string_as_none`, applied to the `amount`/`fees_paid` fields of
**inbound** types only:

- `LookupInvoiceResponse`
- `MakeHoldInvoiceResponse`
- `PaymentNotification`
- `HoldInvoiceAcceptedNotification`

The request types deliberately keep `amount` required — those describe what the
caller sends, where a defaulted amount would silently mean "zero-amount".

`created_at` is left as-is: relaxing it needs `Option<Timestamp>` or a sentinel,
which felt like a separate decision for you to make. Happy to include it either way.

Serialization is unchanged, so round-trips keep emitting both fields.

## Testing

Added `test_lookup_invoice_response_tolerates_missing_and_null_amounts`, which uses
the exact response shape observed from Alby. `cargo test -p nostr --lib --features
nip47 nip47` passes (15 tests), and clippy is clean on the crate.

Note: I could not complete a full `just precommit` — it exhausted the disk on my
machine while building the whole workspace, unrelated to this change. Targeted tests
and clippy on `nostr` are green.

Found while debugging a Mostro protocol test harness, where this presented for days
as "the wallet is dead server-side".