### PR TITLE
lmdb: move `negentropy_items` query to `spawn_blocking`

### DIFF
--- a/database/nostr-lmdb/src/store/mod.rs
+++ b/database/nostr-lmdb/src/store/mod.rs
@@ -134,16 +134,19 @@ impl Store {
         &self,
         filter: Filter,
     ) -> Result<Vec<(EventId, Timestamp)>, StoreError> {
-        let txn = self.db.read_txn()?;
-        let events = self.db.query(&txn, filter)?;
-        let now = Timestamp::now();
-        let items = events
-            .into_iter()
-            .filter(|event| !event.is_expired_at(now))
-            .map(|e| (EventId::from_byte_array(*e.id), e.created_at))
-            .collect();
-        txn.commit()?;
-        Ok(items)
+        self.interact(move |db| {
+            let txn = db.read_txn()?;
+            let events = db.query(&txn, filter)?;
+            let now = Timestamp::now();
+            let items = events
+                .into_iter()
+                .filter(|event| !event.is_expired_at(now))
+                .map(|e| (EventId::from_byte_array(*e.id), e.created_at))
+                .collect();
+            txn.commit()?;
+            Ok(items)
+        })
+        .await?
     }
 
     pub(super) async fn delete(&self, filter: Filter) -> Result<(), StoreError> {


### PR DESCRIPTION
Run `negentropy_items` through the `interact` path so slow LMDB queries don't block the async executor, matching `query`, `count`, and the other read methods.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/nostrdevkit/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the relevant `CHANGELOG.md` (if applicable)
- [X] I understand and can explain all code in this PR
