### PR TITLE
sdk(local_relay): add LocalRelay::connections_left

### DIFF
--- a/nostr-sdk/CHANGELOG.md
+++ b/nostr-sdk/CHANGELOG.md
@@ -27,6 +27,13 @@
 
 -->
 
+
+## Unreleased
+
+### Added
+
+- local_relay: add `LocalRelay::connections_left` (https://github.com/nostrdevkit/nostr/pull/1459)
+
 ## v0.45.2 - 2026/08/19
 
 ### Fixed

--- a/nostr-sdk/src/local_relay/local/inner.rs
+++ b/nostr-sdk/src/local_relay/local/inner.rs
@@ -59,7 +59,7 @@ pub(super) struct InnerLocalRelay {
     auth_events_per_minute: u32,
     messages_per_minute: u32,
     pending_handshakes_limit: Arc<Semaphore>,
-    connections_limit: Arc<Semaphore>,
+    pub(crate) connections_limit: Arc<Semaphore>,
     max_websocket_message_size: usize,
     max_event_size: usize,
     websocket_handshake_timeout: Duration,

--- a/nostr-sdk/src/local_relay/local/mod.rs
+++ b/nostr-sdk/src/local_relay/local/mod.rs
@@ -95,6 +95,12 @@ impl LocalRelay {
         self.inner.url().await
     }
 
+    /// Returns the remaining connection capacity before the limit is reached.
+    #[inline]
+    pub fn connections_left(&self) -> usize {
+        self.inner.connections_limit.available_permits()
+    }
+
     /// Sync events with other relay(s).
     #[inline]
     pub async fn sync_with<'a, I, U>(


### PR DESCRIPTION
Returns the number of remaining connections the relay can handle.

Useful for relays that use `LocalRelay::take_connection` with an already upgraded connection, avoiding CPU waste on connections that would be rejected due to capacity limits.

Refs #1458

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/nostrdevkit/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the relevant `CHANGELOG.md` (if applicable)
- [X] I understand and can explain all code in this PR
