### PR TITLE
GC for database

### DIFF
--- a/database/nostr-database-test-suite/src/lib.rs
+++ b/database/nostr-database-test-suite/src/lib.rs
@@ -1055,5 +1055,42 @@ macro_rules! database_unit_tests {
             let status = store.save_event(&new_event).await.unwrap();
             assert_eq!(status, SaveEventStatus::Rejected(RejectedReason::Vanished));
         }
+
+        #[tokio::test]
+        async fn test_expire_events() {
+            let store: $store_type = $setup_fn().await;
+            let features = store.features();
+
+            if !features.event_expiration {
+                println!("Skipping event expiration tests as the database doesn't support it!");
+                return;
+            }
+
+            let keys = Keys::generate();
+            let event = EventBuilder::new(Kind::TextNote, "Nothing in my mind")
+                .tag(Tag::expiration(Timestamp::now() - 10))
+                .finalize(&keys)
+                .unwrap();
+
+            assert!(
+                store.save_event(&event).await.unwrap().is_success(),
+                "Database should not check if the event is expired"
+            );
+
+            let count = store
+                .count(Filter::new().author(keys.public_key()))
+                .await
+                .unwrap();
+            assert_eq!(count, 1, "We stored a single event");
+
+            // Remove expired events
+            store.collect_garbage().await.unwrap();
+
+            let count = store
+                .count(Filter::new().author(keys.public_key()))
+                .await
+                .unwrap();
+            assert_eq!(count, 0, "Garbage collected");
+        }
     };
 }

--- a/database/nostr-database/CHANGELOG.md
+++ b/database/nostr-database/CHANGELOG.md
@@ -27,6 +27,12 @@
 
 -->
 
+## Unreleased
+
+### Added
+
+- New function to collect garbage `NostrDatabase::collect_garbage` (https://github.com/nostrdevkit/nostr/pull/1474)
+
 ## v0.45.1 - 2026/08/07
 
 ### Fixed

--- a/database/nostr-database/src/lib.rs
+++ b/database/nostr-database/src/lib.rs
@@ -198,4 +198,9 @@ pub trait NostrDatabase: Any + Debug + Send + Sync {
 
     /// Wipe all data
     fn wipe(&self) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>>;
+
+    /// Cleans up expired events and other unused resources.
+    fn collect_garbage(&self) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>> {
+        Box::pin(async { Ok(()) })
+    }
 }

--- a/database/nostr-lmdb/CHANGELOG.md
+++ b/database/nostr-lmdb/CHANGELOG.md
@@ -27,6 +27,12 @@
 
 -->
 
+## Unreleased
+
+### Added
+
+- Support event expiration (https://github.com/nostrdevkit/nostr/pull/1474)
+
 ## v0.45.2 - 2026/08/19
 
 ### Fixed

--- a/database/nostr-lmdb/src/lib.rs
+++ b/database/nostr-lmdb/src/lib.rs
@@ -180,7 +180,7 @@ impl NostrDatabase for NostrLmdb {
     fn features(&self) -> Features {
         Features {
             persistent: true,
-            event_expiration: false,
+            event_expiration: true,
             full_text_search: true,
             request_to_vanish: true,
         }
@@ -238,6 +238,13 @@ impl NostrDatabase for NostrLmdb {
     #[inline]
     fn wipe(&self) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>> {
         Box::pin(async move { Ok(self.db.wipe().await?) })
+    }
+
+    fn collect_garbage(&self) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>> {
+        Box::pin(async move {
+            self.db.delete_expired().await?;
+            Ok(())
+        })
     }
 }
 

--- a/database/nostr-lmdb/src/store/event.rs
+++ b/database/nostr-lmdb/src/store/event.rs
@@ -59,6 +59,16 @@ impl<'a> DatabaseTag<'a> {
         }
     }
 
+    /// Return the expiration timestamp if it's `expiration` tag
+    #[inline]
+    pub(super) fn expiration(&self) -> Option<u64> {
+        if self.kind() == "expiration" {
+            return self.content().and_then(|t| u64::from_str(t).ok());
+        }
+
+        None
+    }
+
     /// Into owned tag
     pub(super) fn into_owned(self) -> Tag {
         let buf: Vec<String> = self.buf.into_iter().map(|t| t.into_owned()).collect();

--- a/database/nostr-lmdb/src/store/ingester.rs
+++ b/database/nostr-lmdb/src/store/ingester.rs
@@ -42,6 +42,10 @@ enum OperationResult {
         result: Result<(), StoreError>,
         tx: Option<oneshot::Sender<Result<(), StoreError>>>,
     },
+    DeleteExpired {
+        result: Result<(), StoreError>,
+        tx: Option<oneshot::Sender<Result<(), StoreError>>>,
+    },
     Wipe {
         result: Result<(), StoreError>,
         tx: Option<oneshot::Sender<Result<(), StoreError>>>,
@@ -79,6 +83,15 @@ impl OperationResult {
                     tracing::error!(error = %e, "Delete operation failed in batch");
                 }
             }
+            Self::DeleteExpired { result, tx } => {
+                if let Some(tx) = tx {
+                    if tx.send(result).is_err() {
+                        tracing::debug!("Failed to send delete expired result: receiver dropped");
+                    }
+                } else if let Err(e) = result {
+                    tracing::error!(error = %e, "delete expired operation failed in batch");
+                }
+            }
             Self::Wipe { result, tx } => {
                 if let Some(tx) = tx {
                     if tx.send(result).is_err() {
@@ -104,6 +117,9 @@ enum IngesterOperation {
         filter: Filter,
         tx: Option<oneshot::Sender<Result<(), StoreError>>>,
     },
+    DeleteExpired {
+        tx: Option<oneshot::Sender<Result<(), StoreError>>>,
+    },
     Wipe {
         tx: Option<oneshot::Sender<Result<(), StoreError>>>,
     },
@@ -122,6 +138,10 @@ impl IngesterOperation {
                 tx,
             },
             Self::Delete { tx, .. } => OperationResult::Delete {
+                result: Err(error),
+                tx,
+            },
+            Self::DeleteExpired { tx } => OperationResult::DeleteExpired {
                 result: Err(error),
                 tx,
             },
@@ -171,6 +191,16 @@ impl IngesterItem {
                 filter,
                 tx: Some(tx),
             },
+        };
+        (item, rx)
+    }
+
+    #[must_use]
+    pub(super) fn delete_expired_with_feedback() -> (Self, oneshot::Receiver<Result<(), StoreError>>)
+    {
+        let (tx, rx) = oneshot::channel();
+        let item: Self = Self {
+            operation: IngesterOperation::DeleteExpired { tx: Some(tx) },
         };
         (item, rx)
     }
@@ -342,6 +372,10 @@ impl Ingester {
                 let result = self.db.delete(txn, filter);
                 OperationResult::Delete { result, tx }
             }
+            IngesterOperation::DeleteExpired { tx } => {
+                let result = self.db.delete_expired(txn);
+                OperationResult::DeleteExpired { result, tx }
+            }
             IngesterOperation::Wipe { tx } => {
                 let result = self.db.wipe(txn);
                 OperationResult::Wipe { result, tx }
@@ -362,6 +396,9 @@ fn mark_all_as_failed(results: &mut [OperationResult]) {
                 *res = Err(StoreError::BatchTransactionFailed)
             }
             OperationResult::Delete { result: res, .. } => {
+                *res = Err(StoreError::BatchTransactionFailed)
+            }
+            OperationResult::DeleteExpired { result: res, .. } => {
                 *res = Err(StoreError::BatchTransactionFailed)
             }
             OperationResult::Wipe { result: res, .. } => {

--- a/database/nostr-lmdb/src/store/lmdb/index.rs
+++ b/database/nostr-lmdb/src/store/lmdb/index.rs
@@ -18,10 +18,14 @@ const KIND_BE: usize = 2;
 const TAG_VALUE_PAD_LEN: usize = 182;
 
 // TODO: use fixed-size arrays instead of vectors
+// TODO: convert `TagIndexKeySet` to an enum instead of `is_indexable`?
 pub(super) struct TagIndexKeySet {
+    /// Whether the tag is indexable
+    pub(super) is_indexable: bool,
     pub(super) atc_index: Vec<u8>,
     pub(super) ktc_index: Vec<u8>,
     pub(super) tc_index: Vec<u8>,
+    pub(super) expiration: Option<u64>,
 }
 
 // TODO: use fixed-size arrays instead of vectors
@@ -49,7 +53,7 @@ impl EventIndexKeys {
         // Index by kind (with created_at and id)
         let kc_index: Vec<u8> = make_kc_index_key(event.kind, event.created_at, event.id);
 
-        let tags = event
+        let mut tags: Vec<TagIndexKeySet> = event
             .tags
             .iter()
             .filter_map(|t| t.extract())
@@ -77,12 +81,29 @@ impl EventIndexKeys {
                     make_tc_index_key(&tag_name, tag_value, event.created_at, event.id);
 
                 TagIndexKeySet {
+                    is_indexable: true,
                     atc_index,
                     ktc_index,
                     tc_index,
+                    expiration: None,
                 }
             })
             .collect();
+
+        // Collect expiration tags, they can't be with `tags` because it's not a single letter tag
+        let expiration_tags = event
+            .tags
+            .iter()
+            .filter_map(|t| t.expiration())
+            .map(|expire_at| TagIndexKeySet {
+                is_indexable: false,
+                atc_index: Vec::new(),
+                ktc_index: Vec::new(),
+                tc_index: Vec::new(),
+                expiration: Some(expire_at),
+            });
+        // Extend the tags with expiration tags
+        tags.extend(expiration_tags);
 
         Self {
             id: *event.id,

--- a/database/nostr-lmdb/src/store/lmdb/mod.rs
+++ b/database/nostr-lmdb/src/store/lmdb/mod.rs
@@ -22,12 +22,13 @@ use super::error::{MigrationError, StoreError};
 use super::event::DatabaseEvent;
 use super::filter::DatabaseFilter;
 use crate::NostrLmdbBuilder;
+use crate::store::event::DatabaseTag;
 
 const EVENT_ID_ALL_ZEROS: [u8; 32] = [0; 32];
 const EVENT_ID_ALL_255: [u8; 32] = [255; 32];
 
 /// Current database schema version
-const DB_VERSION: u64 = 2;
+const DB_VERSION: u64 = 3;
 const DB_VERSION_KEY: &[u8] = b"db_version";
 
 #[derive(Debug)]
@@ -109,6 +110,8 @@ pub(crate) struct Lmdb {
     deleted_coordinates: Database<Bytes, U64<NativeEndian>>, // Coordinate, UNIX timestamp
     /// Vanished public keys
     vanished_public_keys: Database<Bytes, Unit>, // Public key
+    /// Event expiration tracker
+    expirations: Database<Bytes, U64<NativeEndian>>, // Event ID, Expiration timestamp
     /// Database metadata (version, etc)
     metadata: Database<Bytes, U64<NativeEndian>>, // Key, Value
 }
@@ -119,7 +122,7 @@ impl Lmdb {
         let env: Env = unsafe {
             EnvOpenOptions::new()
                 .flags(EnvFlags::NO_TLS)
-                .max_dbs(12 + builder.additional_dbs)
+                .max_dbs(13 + builder.additional_dbs)
                 .max_readers(builder.max_readers)
                 .map_size(builder.map_size)
                 .open(builder.path)?
@@ -183,6 +186,11 @@ impl Lmdb {
             .types::<Bytes, Unit>()
             .name("vanished-public-keys")
             .create(&mut txn)?;
+        let expirations = env
+            .database_options()
+            .types::<Bytes, U64<NativeEndian>>()
+            .name("expirations")
+            .create(&mut txn)?;
         let metadata = env
             .database_options()
             .types::<Bytes, U64<NativeEndian>>()
@@ -212,6 +220,7 @@ impl Lmdb {
             deleted_ids,
             deleted_coordinates,
             vanished_public_keys,
+            expirations,
             metadata,
         };
 
@@ -239,6 +248,10 @@ impl Lmdb {
                 // Run migrations sequentially
                 if current_version < 2 {
                     self.migrate_v1_to_v2(&mut txn)?;
+                }
+
+                if current_version < 3 {
+                    self.migrate_v2_to_v3(&mut txn)?;
                 }
 
                 // Update version
@@ -296,6 +309,51 @@ impl Lmdb {
         Ok(())
     }
 
+    /// Migrates the database from schema version 2 to version 3 by building
+    /// an expiration tracker for events with `expiration` tags.
+    fn migrate_v2_to_v3(&self, txn: &mut RwTxn) -> Result<(), StoreError> {
+        tracing::info!("Starting migration to schema v3: Building expiration tracker");
+        tracing::debug!(
+            "Scanning {} total events for expiration tags",
+            self.events.len(txn)?
+        );
+
+        // Collect all events containing expiration timestamps
+        let expiring_events: Vec<([u8; 32], u64)> = {
+            let mut events_with_expiration = Vec::new();
+            for result in self.events.iter(txn)? {
+                let (_, event_bytes) = result?;
+
+                // Decode event
+                if let Ok(event) = DatabaseEvent::from_flatbuf(event_bytes) {
+                    // Extract expiration timestamp from event tags
+                    if let Some(timestamp) = event.tags.iter().find_map(DatabaseTag::expiration) {
+                        events_with_expiration.push((*event.id, timestamp));
+                    }
+                }
+            }
+            events_with_expiration
+        };
+
+        tracing::info!(
+            "Found {} events with expiration tags",
+            expiring_events.len(),
+        );
+
+        // Build expiration index
+        tracing::debug!("Building expiration index entries");
+        for (event_id, expire_at) in expiring_events.iter() {
+            self.expirations.put(txn, event_id, expire_at)?;
+        }
+
+        tracing::info!(
+            "Successfully migrated to schema v3: Created expiration tracker with {} entries",
+            expiring_events.len()
+        );
+
+        Ok(())
+    }
+
     /// Get a read transaction
     ///
     /// This should never block the current thread
@@ -334,9 +392,17 @@ impl Lmdb {
         self.kc_index.put(txn, &index.kc_index, &index.id)?;
 
         for tag in index.tags.into_iter() {
-            self.atc_index.put(txn, &tag.atc_index, &index.id)?;
-            self.ktc_index.put(txn, &tag.ktc_index, &index.id)?;
-            self.tc_index.put(txn, &tag.tc_index, &index.id)?;
+            // If the tag is indexable means it is a single letter tag that we index
+            if tag.is_indexable {
+                self.atc_index.put(txn, &tag.atc_index, &index.id)?;
+                self.ktc_index.put(txn, &tag.ktc_index, &index.id)?;
+                self.tc_index.put(txn, &tag.tc_index, &index.id)?;
+            }
+
+            // The expiration tag is not indexable, it's just in the `expirations` tracker
+            if let Some(ref timestamp) = tag.expiration {
+                self.expirations.put(txn, &index.id, timestamp)?;
+            }
         }
 
         Ok(())
@@ -368,9 +434,12 @@ impl Lmdb {
 
         // Delete tag indexes
         for tag in &index.tags {
-            self.atc_index.delete(txn, &tag.atc_index)?;
-            self.ktc_index.delete(txn, &tag.ktc_index)?;
-            self.tc_index.delete(txn, &tag.tc_index)?;
+            if tag.is_indexable {
+                self.atc_index.delete(txn, &tag.atc_index)?;
+                self.ktc_index.delete(txn, &tag.ktc_index)?;
+                self.tc_index.delete(txn, &tag.tc_index)?;
+            }
+            self.expirations.delete(txn, &index.id)?;
         }
 
         Ok(())
@@ -397,6 +466,7 @@ impl Lmdb {
         self.deleted_ids.clear(txn)?;
         self.deleted_coordinates.clear(txn)?;
         self.vanished_public_keys.clear(txn)?;
+        self.expirations.clear(txn)?;
         Ok(())
     }
 
@@ -545,6 +615,41 @@ impl Lmdb {
 
         // Now we can safely mutate the transaction
         for index in indexes {
+            self.remove(txn, &index)?;
+        }
+
+        Ok(())
+    }
+
+    /// Delete expired events
+    pub fn delete_expired(&self, txn: &mut RwTxn) -> Result<(), StoreError> {
+        tracing::info!(
+            "Processing {} events that can expire",
+            self.expirations.len(txn)?
+        );
+
+        // Collect all expired events
+        let expired_indexes = {
+            let now = Timestamp::now().as_secs();
+            let mut expired = Vec::new();
+            for result in self.expirations.iter(txn)? {
+                let (event_id, expire_at) = result?;
+                if now >= expire_at {
+                    if let Some(event_index_keys) = self
+                        .get_event_by_id(txn, event_id)?
+                        .map(EventIndexKeys::new)
+                    {
+                        expired.push(event_index_keys);
+                    }
+                }
+            }
+            expired
+        };
+
+        tracing::info!("Found {} expired events", expired_indexes.len());
+
+        // Remove them, we can safely mutate the transaction
+        for index in expired_indexes {
             self.remove(txn, &index)?;
         }
 

--- a/database/nostr-lmdb/src/store/mod.rs
+++ b/database/nostr-lmdb/src/store/mod.rs
@@ -122,7 +122,14 @@ impl Store {
 
             let txn: RoTxn = db.read_txn()?;
             let output = db.query(&txn, filter)?;
-            events.extend(output.into_iter().map(|e| e.into_owned()));
+            let now = Timestamp::now();
+
+            events.extend(
+                output
+                    .into_iter()
+                    .filter(|e| !e.is_expired_at(now))
+                    .map(|e| e.into_owned()),
+            );
             txn.commit()?;
 
             Ok(events)
@@ -151,6 +158,14 @@ impl Store {
 
     pub(super) async fn delete(&self, filter: Filter) -> Result<(), StoreError> {
         let (item, rx) = IngesterItem::delete_with_feedback(filter);
+        self.ingester
+            .send(item)
+            .map_err(|_| StoreError::FlumeSend)?;
+        rx.await?
+    }
+
+    pub(super) async fn delete_expired(&self) -> Result<(), StoreError> {
+        let (item, rx) = IngesterItem::delete_expired_with_feedback();
         self.ingester
             .send(item)
             .map_err(|_| StoreError::FlumeSend)?;

--- a/database/nostr-ndb/src/lib.rs
+++ b/database/nostr-ndb/src/lib.rs
@@ -191,6 +191,11 @@ impl NostrDatabase for NdbDatabase {
     fn wipe(&self) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>> {
         Box::pin(async move { Err(Error::unsupported("wiping is not supported by nostrdb")) })
     }
+
+    #[inline]
+    fn collect_garbage(&self) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>> {
+        Box::pin(async move { Err(Error::unsupported("delete is not supported by nostrdb")) })
+    }
 }
 
 fn ndb_query<'a>(


### PR DESCRIPTION
### Description

A way to clean up database garbage. It has two parts: the database part and the database user part (where the user can be a client or a relay).

The database handles the deletion, and the user manages when and how to collect the garbage. That makes it kinda flexible, crate users don't have to depend on the SDK to clean garbage, so they can handle it themselves however they want.

Also, I named it `NostrDatabase::collect_garbage` instead of naming it specifically after expired events, because a user might wrap our database or implement their own and consider other things garbage too. It just makes more sense to name it like this.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/nostrdevkit/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the relevant `CHANGELOG.md` (if applicable)
- [X] I understand and can explain all code in this PR
